### PR TITLE
Fix analyzer errors and centralize package versions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,4 +1,7 @@
 <Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Serilog.AspNetCore" Version="8.0.0" />
     <PackageVersion Include="Serilog.Settings.Configuration" Version="8.0.0" />
@@ -7,6 +10,7 @@
     <PackageVersion Include="Asp.Versioning.Http" Version="8.0.0" />
     <PackageVersion Include="Asp.Versioning.Mvc" Version="8.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.RateLimiting" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="8.0.20" />
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
     <PackageVersion Include="xunit" Version="2.6.6" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.6" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,12 +5,10 @@
   <ItemGroup>
     <PackageVersion Include="Serilog.AspNetCore" Version="8.0.0" />
     <PackageVersion Include="Serilog.Settings.Configuration" Version="8.0.0" />
-    <PackageVersion Include="Serilog.Sinks.Console" Version="4.1.0" />
+    <PackageVersion Include="Serilog.Sinks.Console" Version="5.0.0" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageVersion Include="Asp.Versioning.Http" Version="8.0.0" />
     <PackageVersion Include="Asp.Versioning.Mvc" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.RateLimiting" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="8.0.20" />
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
     <PackageVersion Include="xunit" Version="2.6.6" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.6" />

--- a/src/RpnCalc.Api/Contracts/Evaluations.cs
+++ b/src/RpnCalc.Api/Contracts/Evaluations.cs
@@ -10,9 +10,9 @@ public sealed record EvaluateSettings(int? Precision, MidpointRounding? Rounding
 {
     public CalcSettings ToCalcSettings()
     {
-        Precision precision = new Precision(Precision ?? CalcSettings.Default.Precision.Digits);
+        Precision precision = new(Precision ?? CalcSettings.Default.Precision.Digits);
         MidpointRounding rounding = Rounding ?? CalcSettings.Default.Rounding;
-        return new CalcSettings(precision, rounding);
+        return new(precision, rounding);
     }
 }
 
@@ -22,6 +22,6 @@ public sealed record EvaluateResponse(string Result, ExpressionMode Mode, IReadO
     {
         List<string> rpn = result.RpnTokens.Select(token => token.Text).ToList();
         string formatted = result.Value.ToString(CultureInfo.InvariantCulture);
-        return new EvaluateResponse(formatted, mode, rpn, result.Trace);
+        return new(formatted, mode, rpn, result.Trace);
     }
 }

--- a/src/RpnCalc.Api/Contracts/Evaluations.cs
+++ b/src/RpnCalc.Api/Contracts/Evaluations.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using RpnCalc.Application.ValueObjects;
+using RpnCalc.Domain.ValueObjects;
+
+namespace RpnCalc.Api.Contracts;
+
+public sealed record EvaluateSettings(int? Precision, MidpointRounding? Rounding)
+{
+    public CalcSettings ToCalcSettings()
+    {
+        Precision precision = new Precision(Precision ?? CalcSettings.Default.Precision.Digits);
+        MidpointRounding rounding = Rounding ?? CalcSettings.Default.Rounding;
+        return new CalcSettings(precision, rounding);
+    }
+}
+
+public sealed record EvaluateResponse(string Result, ExpressionMode Mode, IReadOnlyList<string> Rpn, IReadOnlyList<string> Trace)
+{
+    public static EvaluateResponse From(EvaluationResult result, ExpressionMode mode)
+    {
+        List<string> rpn = result.RpnTokens.Select(token => token.Text).ToList();
+        string formatted = result.Value.ToString(CultureInfo.InvariantCulture);
+        return new EvaluateResponse(formatted, mode, rpn, result.Trace);
+    }
+}

--- a/src/RpnCalc.Api/Contracts/Extensions.cs
+++ b/src/RpnCalc.Api/Contracts/Extensions.cs
@@ -1,0 +1,34 @@
+using System;
+using RpnCalc.Application.Commands;
+
+namespace RpnCalc.Api.Contracts;
+
+public static class MemoryCommandExtensions
+{
+    public static MemoryCommandType ToCommand(this MemoryCommand command)
+    {
+        return command switch
+        {
+            MemoryCommand.MC => MemoryCommandType.Clear,
+            MemoryCommand.MR => MemoryCommandType.Recall,
+            MemoryCommand.MS => MemoryCommandType.Store,
+            MemoryCommand.MPlus => MemoryCommandType.Add,
+            MemoryCommand.MMinus => MemoryCommandType.Subtract,
+            _ => throw new ArgumentOutOfRangeException(nameof(command))
+        };
+    }
+}
+
+public static class ClearScopeExtensions
+{
+    public static ClearScope ToScope(this ClearScopeDto scope)
+    {
+        return scope switch
+        {
+            ClearScopeDto.CE => ClearScope.Entry,
+            ClearScopeDto.C => ClearScope.All,
+            ClearScopeDto.BACKSPACE => ClearScope.Backspace,
+            _ => throw new ArgumentOutOfRangeException(nameof(scope))
+        };
+    }
+}

--- a/src/RpnCalc.Api/Contracts/Requests.cs
+++ b/src/RpnCalc.Api/Contracts/Requests.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+using RpnCalc.Application.Commands;
+using RpnCalc.Application.ValueObjects;
+
+namespace RpnCalc.Api.Contracts;
+
+public sealed record EvaluateRequest(
+    string Expression,
+    ExpressionMode Mode,
+    bool ReturnTrace,
+    EvaluateSettings? Settings,
+    string? SessionId);
+
+public sealed record KeyPressRequest(
+    IReadOnlyList<string> Keys,
+    ExpressionMode Mode,
+    bool ReturnTrace,
+    EvaluateSettings? Settings,
+    string? SessionId);
+
+public sealed record MemoryRequest(string SessionId, MemoryCommand Command, decimal? Value);
+
+public sealed record ClearRequest(ClearScopeDto Scope);
+
+public enum MemoryCommand
+{
+    MC,
+    MR,
+    MS,
+    MPlus,
+    MMinus
+}
+
+public enum ClearScopeDto
+{
+    CE,
+    C,
+    BACKSPACE
+}

--- a/src/RpnCalc.Api/Infrastructure/PassthroughExceptionHandler.cs
+++ b/src/RpnCalc.Api/Infrastructure/PassthroughExceptionHandler.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Http;
+
+namespace RpnCalc.Api.Infrastructure;
+
+public sealed class PassthroughExceptionHandler : IExceptionHandler
+{
+    public ValueTask<bool> TryHandleAsync(HttpContext httpContext, Exception exception, CancellationToken cancellationToken)
+    {
+        return ValueTask.FromResult(false);
+    }
+}

--- a/src/RpnCalc.Api/Program.cs
+++ b/src/RpnCalc.Api/Program.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using System.Text.Json.Serialization;
 using Asp.Versioning;
 using Microsoft.AspNetCore.Builder;
@@ -68,7 +69,8 @@ builder.Services.AddApiVersioning(options =>
 builder.Services.ConfigureHttpJsonOptions(options =>
 {
     options.SerializerOptions.Converters.Add(new JsonStringEnumConverter());
-    options.SerializerOptions.PropertyNamingPolicy = null;
+    options.SerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
+    options.SerializerOptions.DictionaryKeyPolicy = JsonNamingPolicy.CamelCase;
 });
 
 WebApplication app = builder.Build();

--- a/src/RpnCalc.Api/RpnCalc.Api.csproj
+++ b/src/RpnCalc.Api/RpnCalc.Api.csproj
@@ -15,8 +15,6 @@
     <PackageReference Include="Swashbuckle.AspNetCore" />
     <PackageReference Include="Asp.Versioning.Http" />
     <PackageReference Include="Asp.Versioning.Mvc" />
-    <PackageReference Include="Microsoft.AspNetCore.RateLimiting" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../RpnCalc.Application/RpnCalc.Application.csproj" />

--- a/src/RpnCalc.Api/RpnCalc.Api.csproj
+++ b/src/RpnCalc.Api/RpnCalc.Api.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Asp.Versioning.Http" />
     <PackageReference Include="Asp.Versioning.Mvc" />
     <PackageReference Include="Microsoft.AspNetCore.RateLimiting" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../RpnCalc.Application/RpnCalc.Application.csproj" />

--- a/src/RpnCalc.Application/Commands/ApplyMemoryCommand.cs
+++ b/src/RpnCalc.Application/Commands/ApplyMemoryCommand.cs
@@ -30,8 +30,8 @@ public sealed class ApplyMemoryCommandHandler
             throw new ArgumentException("Session id is required.", nameof(command));
         }
 
-        var register = _memoryStore.GetOrCreate(command.SessionId);
-        var result = Execute(command, register);
+        MemoryRegister register = _memoryStore.GetOrCreate(command.SessionId);
+        MemoryRegister result = Execute(command, register);
         Persist(command, result);
         return result.Value;
     }

--- a/src/RpnCalc.Application/Commands/EvaluateExpressionCommand.cs
+++ b/src/RpnCalc.Application/Commands/EvaluateExpressionCommand.cs
@@ -32,8 +32,8 @@ public sealed class EvaluateExpressionCommandHandler
             throw new ArgumentException("Expression is required.", nameof(command));
         }
 
-        var settings = command.Settings ?? CalcSettings.Default;
-        var rpn = CreateRpn(command, settings);
+        CalcSettings settings = command.Settings ?? CalcSettings.Default;
+        RpnExpression rpn = CreateRpn(command, settings);
         return _evaluator.Evaluate(rpn, settings, command.ReturnTrace);
     }
 
@@ -46,15 +46,15 @@ public sealed class EvaluateExpressionCommandHandler
 
     private RpnExpression ConvertFromInfix(string expression, CalcSettings settings)
     {
-        var tokens = _tokenizer.Tokenize(new InfixExpression(expression));
+        IReadOnlyList<Token> tokens = _tokenizer.Tokenize(new InfixExpression(expression));
         return _converter.Convert(tokens);
     }
 
     private static RpnExpression ParseRpn(string expression)
     {
-        var tokens = new List<Token>();
-        var span = expression.Split(' ', StringSplitOptions.RemoveEmptyEntries);
-        foreach (var part in span)
+        List<Token> tokens = new List<Token>();
+        string[] span = expression.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        foreach (string part in span)
         {
             tokens.Add(ParseToken(part));
         }
@@ -64,7 +64,7 @@ public sealed class EvaluateExpressionCommandHandler
 
     private static Token ParseToken(string symbol)
     {
-        if (decimal.TryParse(symbol, NumberStyles.Number, CultureInfo.InvariantCulture, out var value))
+        if (decimal.TryParse(symbol, NumberStyles.Number, CultureInfo.InvariantCulture, out decimal value))
         {
             return new NumberLiteral(value, symbol);
         }

--- a/src/RpnCalc.Application/Commands/EvaluateExpressionCommand.cs
+++ b/src/RpnCalc.Application/Commands/EvaluateExpressionCommand.cs
@@ -52,7 +52,7 @@ public sealed class EvaluateExpressionCommandHandler
 
     private static RpnExpression ParseRpn(string expression)
     {
-        List<Token> tokens = new List<Token>();
+        List<Token> tokens = new();
         string[] span = expression.Split(' ', StringSplitOptions.RemoveEmptyEntries);
         foreach (string part in span)
         {

--- a/src/RpnCalc.Application/Commands/ProcessKeysCommand.cs
+++ b/src/RpnCalc.Application/Commands/ProcessKeysCommand.cs
@@ -30,7 +30,7 @@ public sealed class ProcessKeysCommandHandler
             return new EvaluationResult(0m, Array.Empty<Token>(), Array.Empty<string>());
         }
 
-        EvaluateExpressionCommand evaluationCommand = new EvaluateExpressionCommand(streamResult.Expression, command.Mode, command.ReturnTrace, command.Settings);
+        EvaluateExpressionCommand evaluationCommand = new(streamResult.Expression, command.Mode, command.ReturnTrace, command.Settings);
         return _evaluator.Handle(evaluationCommand);
     }
 }

--- a/src/RpnCalc.Application/Commands/ProcessKeysCommand.cs
+++ b/src/RpnCalc.Application/Commands/ProcessKeysCommand.cs
@@ -23,14 +23,14 @@ public sealed class ProcessKeysCommandHandler
 
     public EvaluationResult Handle(ProcessKeysCommand command)
     {
-        var mode = command.Mode == ExpressionMode.Infix ? CalculatorMode.Infix : CalculatorMode.Rpn;
-        var streamResult = _interpreter.Interpret(command.Keys, mode);
+        CalculatorMode mode = command.Mode == ExpressionMode.Infix ? CalculatorMode.Infix : CalculatorMode.Rpn;
+        KeyStreamResult streamResult = _interpreter.Interpret(command.Keys, mode);
         if (string.IsNullOrWhiteSpace(streamResult.Expression))
         {
             return new EvaluationResult(0m, Array.Empty<Token>(), Array.Empty<string>());
         }
 
-        var evaluationCommand = new EvaluateExpressionCommand(streamResult.Expression, command.Mode, command.ReturnTrace, command.Settings);
+        EvaluateExpressionCommand evaluationCommand = new EvaluateExpressionCommand(streamResult.Expression, command.Mode, command.ReturnTrace, command.Settings);
         return _evaluator.Handle(evaluationCommand);
     }
 }

--- a/src/RpnCalc.Domain/Services/InfixToRpnConverter.cs
+++ b/src/RpnCalc.Domain/Services/InfixToRpnConverter.cs
@@ -7,9 +7,9 @@ public sealed class InfixToRpnConverter
 {
     public RpnExpression Convert(IReadOnlyList<Token> tokens)
     {
-        var output = new List<Token>();
-        var operators = new Stack<Token>();
-        foreach (var token in tokens)
+        List<Token> output = new List<Token>();
+        Stack<Token> operators = new Stack<Token>();
+        foreach (Token token in tokens)
         {
             HandleToken(token, output, operators);
         }
@@ -37,7 +37,7 @@ public sealed class InfixToRpnConverter
 
     private static void PushOperator(Operator current, ICollection<Token> output, Stack<Token> operators)
     {
-        while (operators.TryPeek(out var top) && top is Operator topOperator && ShouldPop(topOperator, current))
+        while (operators.TryPeek(out Token? top) && top is Operator topOperator && ShouldPop(topOperator, current))
         {
             output.Add(operators.Pop());
         }
@@ -75,7 +75,7 @@ public sealed class InfixToRpnConverter
     {
         while (operators.Count > 0)
         {
-            var token = operators.Pop();
+            Token token = operators.Pop();
             if (token is Parenthesis opening)
             {
                 if (!opening.IsOpening)
@@ -96,7 +96,7 @@ public sealed class InfixToRpnConverter
     {
         while (operators.Count > 0)
         {
-            var token = operators.Pop();
+            Token token = operators.Pop();
             if (token is Parenthesis)
             {
                 throw new ConversionException("Unbalanced parentheses detected.");

--- a/src/RpnCalc.Domain/Services/InfixToRpnConverter.cs
+++ b/src/RpnCalc.Domain/Services/InfixToRpnConverter.cs
@@ -7,8 +7,8 @@ public sealed class InfixToRpnConverter
 {
     public RpnExpression Convert(IReadOnlyList<Token> tokens)
     {
-        List<Token> output = new List<Token>();
-        Stack<Token> operators = new Stack<Token>();
+        List<Token> output = new();
+        Stack<Token> operators = new();
         foreach (Token token in tokens)
         {
             HandleToken(token, output, operators);

--- a/src/RpnCalc.Domain/Services/InfixTokenizer.cs
+++ b/src/RpnCalc.Domain/Services/InfixTokenizer.cs
@@ -8,7 +8,7 @@ public sealed class InfixTokenizer
 {
     public IReadOnlyList<Token> Tokenize(InfixExpression expression)
     {
-        List<Token> builder = new List<Token>();
+        List<Token> builder = new();
         ReadOnlySpan<char> span = expression.Expression.AsSpan();
         int index = 0;
         while (index < span.Length)
@@ -86,7 +86,7 @@ public sealed class InfixTokenizer
             return false;
         }
 
-        bool isUnary = IsUnary(target);
+        bool isUnary = IsUnary((IReadOnlyList<Token>)target);
         target.Add(isUnary ? OperatorCatalog.GetUnary(symbol) : OperatorCatalog.GetBinary(symbol));
         index++;
         return true;

--- a/src/RpnCalc.Domain/Services/InfixTokenizer.cs
+++ b/src/RpnCalc.Domain/Services/InfixTokenizer.cs
@@ -8,9 +8,9 @@ public sealed class InfixTokenizer
 {
     public IReadOnlyList<Token> Tokenize(InfixExpression expression)
     {
-        var builder = new List<Token>();
-        var span = expression.Expression.AsSpan();
-        var index = 0;
+        List<Token> builder = new List<Token>();
+        ReadOnlySpan<char> span = expression.Expression.AsSpan();
+        int index = 0;
         while (index < span.Length)
         {
             if (char.IsWhiteSpace(span[index]))
@@ -48,15 +48,15 @@ public sealed class InfixTokenizer
             return false;
         }
 
-        var start = index;
+        int start = index;
         index++;
         while (index < span.Length && (char.IsDigit(span[index]) || span[index] == '.'))
         {
             index++;
         }
 
-        var literal = span[start..index].ToString();
-        if (!decimal.TryParse(literal, NumberStyles.Number, CultureInfo.InvariantCulture, out var value))
+        string literal = span[start..index].ToString();
+        if (!decimal.TryParse(literal, NumberStyles.Number, CultureInfo.InvariantCulture, out decimal value))
         {
             throw new TokenizationException($"Invalid numeric literal '{literal}'.");
         }
@@ -67,7 +67,7 @@ public sealed class InfixTokenizer
 
     private static bool TryReadParenthesis(ReadOnlySpan<char> span, ref int index, ICollection<Token> target)
     {
-        var ch = span[index];
+        char ch = span[index];
         if (ch != '(' && ch != ')')
         {
             return false;
@@ -80,13 +80,13 @@ public sealed class InfixTokenizer
 
     private static bool TryReadOperator(ReadOnlySpan<char> span, ref int index, IList<Token> target)
     {
-        var symbol = span[index].ToString();
+        string symbol = span[index].ToString();
         if (!OperatorCatalog.IsOperator(span[index]))
         {
             return false;
         }
 
-        var isUnary = IsUnary(target);
+        bool isUnary = IsUnary(target);
         target.Add(isUnary ? OperatorCatalog.GetUnary(symbol) : OperatorCatalog.GetBinary(symbol));
         index++;
         return true;
@@ -99,7 +99,7 @@ public sealed class InfixTokenizer
             return true;
         }
 
-        var previous = tokens[^1];
+        Token previous = tokens[^1];
         if (previous is Parenthesis paren && paren.IsOpening)
         {
             return true;
@@ -112,8 +112,8 @@ public sealed class InfixTokenizer
 
     private static void EnsureBalance(IReadOnlyCollection<Token> tokens)
     {
-        var depth = 0;
-        foreach (var token in tokens)
+        int depth = 0;
+        foreach (Token token in tokens)
         {
             depth = UpdateDepth(token, depth);
             if (depth < 0)

--- a/src/RpnCalc.Domain/Services/KeyStreamInterpreter.cs
+++ b/src/RpnCalc.Domain/Services/KeyStreamInterpreter.cs
@@ -24,9 +24,9 @@ public sealed class KeyStreamInterpreter
 
     private static KeyStreamResult InterpretInfix(IReadOnlyList<string> keys)
     {
-        var buffer = new StringBuilder();
-        var evaluate = false;
-        foreach (var key in keys)
+        StringBuilder buffer = new StringBuilder();
+        bool evaluate = false;
+        foreach (string key in keys)
         {
             if (HandleControlKey(key, buffer, ref evaluate))
             {
@@ -105,9 +105,9 @@ public sealed class KeyStreamInterpreter
 
     private static KeyStreamResult InterpretRpn(IReadOnlyList<string> keys)
     {
-        var buffer = new List<string>();
-        var evaluate = false;
-        foreach (var key in keys)
+        List<string> buffer = new List<string>();
+        bool evaluate = false;
+        foreach (string key in keys)
         {
             if (key == "CE")
             {

--- a/src/RpnCalc.Domain/Services/RpnEvaluator.cs
+++ b/src/RpnCalc.Domain/Services/RpnEvaluator.cs
@@ -7,9 +7,9 @@ public sealed class RpnEvaluator
 {
     public EvaluationResult Evaluate(RpnExpression expression, CalcSettings settings, bool includeTrace)
     {
-        var stack = new Stack<decimal>();
-        var trace = includeTrace ? new List<string>() : new List<string>();
-        foreach (var token in expression.Tokens)
+        Stack<decimal> stack = new Stack<decimal>();
+        List<string> trace = new List<string>();
+        foreach (Token token in expression.Tokens)
         {
             EvaluateToken(token, stack, settings, trace, includeTrace);
         }
@@ -19,7 +19,7 @@ public sealed class RpnEvaluator
             throw new EvaluationException("Expression evaluation ended with unexpected stack state.");
         }
 
-        var value = Round(stack.Pop(), settings);
+        decimal value = Round(stack.Pop(), settings);
         return new EvaluationResult(value, expression.Tokens, trace);
     }
 
@@ -36,7 +36,7 @@ public sealed class RpnEvaluator
 
     private static void PushNumber(decimal value, Stack<decimal> stack, CalcSettings settings, ICollection<string> trace, bool includeTrace)
     {
-        var rounded = Round(value, settings);
+        decimal rounded = Round(value, settings);
         stack.Push(rounded);
         if (includeTrace)
         {
@@ -58,8 +58,8 @@ public sealed class RpnEvaluator
     private static void ApplyUnary(Operator op, Stack<decimal> stack, CalcSettings settings, ICollection<string> trace, bool includeTrace)
     {
         EnsureStack(stack, 1, op.Symbol);
-        var value = stack.Pop();
-        var result = Round(op.ApplyUnary(value), settings);
+        decimal value = stack.Pop();
+        decimal result = Round(op.ApplyUnary(value), settings);
         stack.Push(result);
         if (includeTrace)
         {
@@ -70,9 +70,9 @@ public sealed class RpnEvaluator
     private static void ApplyBinary(Operator op, Stack<decimal> stack, CalcSettings settings, ICollection<string> trace, bool includeTrace)
     {
         EnsureStack(stack, 2, op.Symbol);
-        var right = stack.Pop();
-        var left = stack.Pop();
-        var result = Round(op.ApplyBinary(left, right), settings);
+        decimal right = stack.Pop();
+        decimal left = stack.Pop();
+        decimal result = Round(op.ApplyBinary(left, right), settings);
         stack.Push(result);
         if (includeTrace)
         {

--- a/src/RpnCalc.Domain/ValueObjects/OperatorCatalog.cs
+++ b/src/RpnCalc.Domain/ValueObjects/OperatorCatalog.cs
@@ -15,7 +15,7 @@ public static class OperatorCatalog
 
     public static Operator GetBinary(string symbol)
     {
-        return Operators.TryGetValue(symbol, out var op)
+        return Operators.TryGetValue(symbol, out Operator? op)
             ? op
             : throw new ArgumentException($"Unsupported operator '{symbol}'.", nameof(symbol));
     }
@@ -44,7 +44,7 @@ public static class OperatorCatalog
 
     private static decimal Power(decimal left, decimal right)
     {
-        var result = Math.Pow((double)left, (double)right);
+        double result = Math.Pow((double)left, (double)right);
         return decimal.Parse(result.ToString(CultureInfo.InvariantCulture), CultureInfo.InvariantCulture);
     }
 }

--- a/src/RpnCalc.Domain/ValueObjects/Token.cs
+++ b/src/RpnCalc.Domain/ValueObjects/Token.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+
 namespace RpnCalc.Domain.ValueObjects;
 
 public enum TokenType
@@ -16,7 +18,7 @@ public sealed record NumberLiteral(decimal Value, string Literal) : Token(TokenT
 {
     public static NumberLiteral From(decimal value, int precision)
     {
-        var literal = value.ToString($"F{precision}").TrimEnd('0').TrimEnd('.');
+        string literal = value.ToString($"F{precision}", CultureInfo.InvariantCulture).TrimEnd('0').TrimEnd('.');
         return new NumberLiteral(value, literal);
     }
 }

--- a/src/RpnCalc.Web/angular.json
+++ b/src/RpnCalc.Web/angular.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/angular-cli",
   "version": 1,
-  "defaultProject": "rpn-calc-web",
   "projects": {
     "rpn-calc-web": {
       "projectType": "application",
@@ -25,11 +24,11 @@
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
           "options": {
-            "browserTarget": "rpn-calc-web:build"
+            "buildTarget": "rpn-calc-web:build"
           },
           "configurations": {
             "development": {
-              "browserTarget": "rpn-calc-web:build:development"
+              "buildTarget": "rpn-calc-web:build:development"
             }
           }
         },
@@ -46,5 +45,8 @@
         }
       }
     }
+  },
+  "cli": {
+    "analytics": false
   }
 }

--- a/src/RpnCalc.Web/src/app/components/calculator/calculator.component.ts
+++ b/src/RpnCalc.Web/src/app/components/calculator/calculator.component.ts
@@ -1,6 +1,6 @@
 import { Component, HostListener, OnInit } from '@angular/core';
 import { ApiService } from '../../services/api.service';
-import { EvaluateResponseDto, MemoryRequestDto } from '../../models';
+import { EvaluateResponseDto, MemoryRequestDto, MemoryResponseDto } from '../../models';
 
 type Mode = 'Infix' | 'Rpn';
 
@@ -68,13 +68,13 @@ export class CalculatorComponent implements OnInit {
     };
 
     this.api.applyMemory(payload).subscribe({
-      next: (response) => {
+      next: (response: MemoryResponseDto) => {
         this.memory = response.value;
         if (button === 'MR') {
           this.display = response.value.toString();
         }
       },
-      error: (err) => this.showError(err)
+      error: (err: unknown) => this.showError(err)
     });
   }
 
@@ -113,8 +113,8 @@ export class CalculatorComponent implements OnInit {
     };
 
     this.api.press(request).subscribe({
-      next: (response) => this.applyResponse(response),
-      error: (err) => this.showError(err)
+      next: (response: EvaluateResponseDto) => this.applyResponse(response),
+      error: (err: unknown) => this.showError(err)
     });
 
     if (value === 'C' || value === 'CE') {
@@ -135,8 +135,8 @@ export class CalculatorComponent implements OnInit {
 
   private showError(error: unknown): void {
     if (error && typeof error === 'object' && 'error' in error) {
-      const detail = (error as any).error?.detail ?? 'Unexpected error';
-      this.error = detail;
+      const candidate = error as { error?: { detail?: string } };
+      this.error = candidate.error?.detail ?? 'Unexpected error';
       return;
     }
 
@@ -157,8 +157,12 @@ export class CalculatorComponent implements OnInit {
 
   private loadMemory(): void {
     this.api.getMemory().subscribe({
-      next: (response) => (this.memory = response.value),
-      error: () => (this.memory = 0)
+      next: (response: MemoryResponseDto) => {
+        this.memory = response.value;
+      },
+      error: () => {
+        this.memory = 0;
+      }
     });
   }
 }

--- a/src/RpnCalc.Web/src/app/components/calculator/calculator.component.ts
+++ b/src/RpnCalc.Web/src/app/components/calculator/calculator.component.ts
@@ -128,8 +128,8 @@ export class CalculatorComponent implements OnInit {
 
   private applyResponse(response: EvaluateResponseDto): void {
     this.display = response.result;
-    this.rpn = response.rpn;
-    this.trace = response.trace;
+    this.rpn = response.rpn ?? [];
+    this.trace = response.trace ?? [];
     this.loadMemory();
   }
 

--- a/src/RpnCalc.Web/src/app/services/api.service.ts
+++ b/src/RpnCalc.Web/src/app/services/api.service.ts
@@ -54,6 +54,8 @@ export class ApiService {
   }
 
   clear(request: ClearRequestDto): Observable<string> {
-    return this.http.post<{ cleared: string }>(`${this.baseUrl}/clear`, request).pipe(map((x) => x.cleared));
+    return this.http
+      .post<{ cleared: string }>(`${this.baseUrl}/clear`, request)
+      .pipe(map((response: { cleared: string }) => response.cleared));
   }
 }

--- a/src/RpnCalc.Web/src/main.ts
+++ b/src/RpnCalc.Web/src/main.ts
@@ -1,7 +1,6 @@
-import { enableProdMode } from '@angular/core';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 import { AppModule } from './app/app.module';
 
 platformBrowserDynamic()
   .bootstrapModule(AppModule)
-  .catch((err) => console.error(err));
+  .catch((err: unknown) => console.error(err));

--- a/src/RpnCalc.Web/tsconfig.json
+++ b/src/RpnCalc.Web/tsconfig.json
@@ -10,6 +10,12 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "esModuleInterop": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "target": "ES2022",
+    "useDefineForClassFields": false,
+    "module": "ES2022",
+    "moduleResolution": "node",
+    "lib": ["ES2022", "DOM"],
+    "types": []
   }
 }

--- a/tests/RpnCalc.Tests/Application/EvaluateCommandTests.cs
+++ b/tests/RpnCalc.Tests/Application/EvaluateCommandTests.cs
@@ -2,6 +2,7 @@ using FluentAssertions;
 using RpnCalc.Application.Commands;
 using RpnCalc.Application.ValueObjects;
 using RpnCalc.Domain.Services;
+using RpnCalc.Domain.ValueObjects;
 using Xunit;
 
 namespace RpnCalc.Tests.Application;
@@ -11,10 +12,10 @@ public sealed class EvaluateCommandTests
     [Fact]
     public void Handle_ShouldEvaluateInfixExpression()
     {
-        var handler = CreateHandler();
-        var command = new EvaluateExpressionCommand("1+2", ExpressionMode.Infix, false, null);
+        EvaluateExpressionCommandHandler handler = CreateHandler();
+        EvaluateExpressionCommand command = new EvaluateExpressionCommand("1+2", ExpressionMode.Infix, false, null);
 
-        var result = handler.Handle(command);
+        EvaluationResult result = handler.Handle(command);
 
         result.Value.Should().Be(3m);
     }

--- a/tests/RpnCalc.Tests/Application/MemoryCommandTests.cs
+++ b/tests/RpnCalc.Tests/Application/MemoryCommandTests.cs
@@ -11,11 +11,11 @@ public sealed class MemoryCommandTests
     [Fact]
     public void ApplyMemory_ShouldStoreValue()
     {
-        var store = new FakeMemoryStore();
-        var handler = new ApplyMemoryCommandHandler(store);
-        var command = new ApplyMemoryCommand("session", MemoryCommandType.Store, 5m);
+        FakeMemoryStore store = new FakeMemoryStore();
+        ApplyMemoryCommandHandler handler = new ApplyMemoryCommandHandler(store);
+        ApplyMemoryCommand command = new ApplyMemoryCommand("session", MemoryCommandType.Store, 5m);
 
-        var result = handler.Handle(command);
+        decimal result = handler.Handle(command);
 
         result.Should().Be(5m);
         store.LastSaved.Should().Be(5m);

--- a/tests/RpnCalc.Tests/Domain/ConversionTests.cs
+++ b/tests/RpnCalc.Tests/Domain/ConversionTests.cs
@@ -10,12 +10,12 @@ public sealed class ConversionTests
     [Fact]
     public void Convert_ShouldProduceExpectedRpn()
     {
-        var tokenizer = new InfixTokenizer();
-        var converter = new InfixToRpnConverter();
-        var tokens = tokenizer.Tokenize(new InfixExpression("3 + 4 * 2 / (1 - 5) ^ 2 ^ 3"));
+        InfixTokenizer tokenizer = new InfixTokenizer();
+        InfixToRpnConverter converter = new InfixToRpnConverter();
+        IReadOnlyList<Token> tokens = tokenizer.Tokenize(new InfixExpression("3 + 4 * 2 / (1 - 5) ^ 2 ^ 3"));
 
-        var rpn = converter.Convert(tokens);
-        var sequence = rpn.Tokens.Select(t => t.Text).ToArray();
+        RpnExpression rpn = converter.Convert(tokens);
+        string[] sequence = rpn.Tokens.Select(t => t.Text).ToArray();
 
         sequence.Should().ContainInOrder("3", "4", "2", "*", "1", "5", "-", "2", "3", "^", "^", "/", "+");
     }

--- a/tests/RpnCalc.Tests/Domain/RpnEvaluatorTests.cs
+++ b/tests/RpnCalc.Tests/Domain/RpnEvaluatorTests.cs
@@ -12,14 +12,14 @@ public sealed class RpnEvaluatorTests
     [Fact]
     public void Evaluate_ShouldHandleExponentiation()
     {
-        var expression = new RpnExpression(new Token[]
+        RpnExpression expression = new RpnExpression(new Token[]
         {
             new NumberLiteral(2m, "2"),
             new NumberLiteral(3m, "3"),
             OperatorCatalog.GetBinary("^")
         });
 
-        var result = _evaluator.Evaluate(expression, CalcSettings.Default, false);
+        EvaluationResult result = _evaluator.Evaluate(expression, CalcSettings.Default, false);
 
         result.Value.Should().Be(8m);
     }
@@ -27,7 +27,7 @@ public sealed class RpnEvaluatorTests
     [Fact]
     public void Evaluate_ShouldFailOnInsufficientOperands()
     {
-        var expression = new RpnExpression(new Token[] { OperatorCatalog.GetBinary("+") });
+        RpnExpression expression = new RpnExpression(new Token[] { OperatorCatalog.GetBinary("+") });
 
         Action action = () => _evaluator.Evaluate(expression, CalcSettings.Default, false);
 

--- a/tests/RpnCalc.Tests/Domain/TokenizationTests.cs
+++ b/tests/RpnCalc.Tests/Domain/TokenizationTests.cs
@@ -10,8 +10,8 @@ public sealed class TokenizationTests
     [Fact]
     public void Tokenize_ShouldRecognizeUnaryMinus()
     {
-        var tokenizer = new InfixTokenizer();
-        var tokens = tokenizer.Tokenize(new InfixExpression("(-3.5+2) * 4^2"));
+        InfixTokenizer tokenizer = new InfixTokenizer();
+        IReadOnlyList<Token> tokens = tokenizer.Tokenize(new InfixExpression("(-3.5+2) * 4^2"));
 
         tokens.Should().ContainSingle(t => t.Text == "u-");
     }


### PR DESCRIPTION
## Summary
- enable central package management and pin framework packages, including Microsoft.AspNetCore.OpenApi, to resolve restore warnings
- extract API contracts and exception handler into dedicated namespaces and update Program.cs to use explicit typing and OpenAPI registration
- replace implicit typing and culture-sensitive conversions across domain, application, and tests to satisfy analyzers

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68deb8d60b6083308f21d7089d4913f2